### PR TITLE
Fix install script for non-cloned repositories

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -17,6 +17,28 @@ function usage {
     echo "    -h, --help      Show this message"
 }
 
+function check_git {
+  if ! command -v git &> /dev/null; then
+    echo "Could not find 'git' command, please install it (in Ubuntu: sudo apt install git)."
+    exit 2
+  fi
+}
+
+function check_cdhit_dependencies {
+  # We need a C++ compiler and zlib.
+  if ! command -v g++ &> /dev/null; then
+    echo "Could not find 'g++' command, please install it (in Ubuntu: sudo apt install g++)."
+    exit 2
+  fi
+  # Attempt to compile a small test program that includes a zlib header and
+  # try to link zlib (with -lz option to g++). If this fails, we cannot build CD-HIT.
+  program=$'#include <zlib.h>\nint main() {}'
+  if ! echo "$program" | g++ -o /dev/null -lz -x c++ - > /dev/null; then
+    echo "Could not find 'zlib' library, please install it (in Ubuntu: sudo apt install zlib1g-dev)."
+    exit 79
+  fi
+}
+
 # Parse input arguments
 name=''
 prefix=''
@@ -69,14 +91,39 @@ fi
 # Get the location of this script's path to determine where we find the environment definition and the decona executable.
 script_path=$(dirname "$(realpath "$0")")
 
+# Check whether Decona is a git repository. If it is not, we clone CD-HIT separately, otherwise we use the submodule.
+if [ -d "$script_path/../.git" ]; then
+    if [ -z "$(find "$script_path/../external" -empty)" ]; then
+        echo "Found CD-HIT..."
+    else
+        check_git
+        echo "Cloning CD-HIT submodule..."
+        cd "$script_path/.." && git submodule update --init --recursive > /dev/null
+        if [ $? -ne 0 ]; then
+            echo "Failed to clone CD-HIT submodule"
+            exit 5
+        fi
+    fi
+else
+    check_git
+    echo "Cloning CD-HIT..."
+    # Note: we check out V4.8.1; this should be changed when the submodule is updated to a new version.
+    cd "$script_path/../external" && git clone --recurse-submodules -b V4.8.1 https://github.com/weizhongli/cdhit.git &> /dev/null
+    if [ $? -ne 0 ]; then
+        echo "Failed to clone CD-HIT"
+        exit 5
+    fi
+fi
+
 # Build CD-HIT before trying to make the environment, we want to see any errors from this build before starting the
 # lengthy process of generating an Anaconda environment.
 echo "Building CD-HIT..."
 cd_hit_path="$script_path/../external/cdhit"
+check_cdhit_dependencies
 cd "$cd_hit_path" && make > /dev/null
-if [ $? != 0 ]; then
-    echo "Failed to build CD-HIT, did you clone the repository without --recurse-submodules?"
-    echo "In that case, try running 'git submodule update --init' to also retrieve CD-HIT."
+if [ $? -ne 0 ]; then
+    echo "Failed to build CD-HIT"
+    exit 5
 fi
 
 echo "Creating Python environment and installing packages, this might take a long time..."


### PR DESCRIPTION
The previous install script assumed that the repository would be cloned,
rather than downloaded as an archive in the form of e.g. a GitHub
release.