### PR TITLE
Fix sprintf

### DIFF
--- a/decona
+++ b/decona
@@ -661,7 +661,7 @@ done
 paste percentage_per_barcode.txt percentage2.txt | column -s $'\t' -t > combined.txt || :
 #rm percentage2.txt || :
 cat combined.txt | sed 's/demultiplexed_.*report_//' > combined2.txt || :
-awk '{$3=sprintf("%d\t(%.2f%)", $3, ($3/$2)*100)}1' combined2.txt > percentage_per_barcode.txt || :
+awk '{$3=sprintf("%d\t(%.2f%%)", $3, ($3/$2)*100)}1' combined2.txt > percentage_per_barcode.txt || :
 #rm combined2.txt combined.txt || : 
 
 ######################################################################################################


### PR DESCRIPTION
`awk: run time error: not enough arguments passed to sprintf("%d (%.2f%)")`

Reason: In awk, % has special meaning in sprintf, and to print a literal %, we must use %%.